### PR TITLE
Add Caldera Map

### DIFF
--- a/games/blank.yaml
+++ b/games/blank.yaml
@@ -1,1 +1,0 @@
-game: abc

--- a/games/caldera.yaml
+++ b/games/caldera.yaml
@@ -1,0 +1,1 @@
+game: caldera

--- a/run.py
+++ b/run.py
@@ -8,7 +8,7 @@ from sr.robot import *
 parser = argparse.ArgumentParser()
 parser.add_argument('-c', '--config',
                     type=argparse.FileType('r'),
-                    default='games/abc.yaml')
+                    default='games/caldera.yaml')
 parser.add_argument('robot_scripts',
                     type=argparse.FileType('r'),
                     nargs='*')

--- a/sr/robot/arenas/__init__.py
+++ b/sr/robot/arenas/__init__.py
@@ -3,11 +3,13 @@ from .pirate_plunder_arena import PiratePlunderArena
 from .ctf_arena import CTFArena
 from .sunny_side_up_arena import SunnySideUpArena
 from .abc_arena import ABCArena
+from .caldera_arena import CalderaArena
 
 __all__ = [
     'pirate_plunder_arena',
     'ctf_arena',
     'sunny_side_up_arena',
     'abc_arena',
+    'caldera_arena',
     'arena',
 ]

--- a/sr/robot/arenas/abc_arena.py
+++ b/sr/robot/arenas/abc_arena.py
@@ -1,6 +1,6 @@
 from math import pi
 
-from .arena import Arena, draw_triangular_corner_zones
+from .arena import Arena, draw_corner_zones
 
 from ..markers import Token
 from ..vision import MARKER_TOKEN_A, MARKER_TOKEN_B, MARKER_TOKEN_C
@@ -56,4 +56,4 @@ class ABCArena(Arena):
     def draw_background(self, surface, display):
         super(ABCArena, self).draw_background(surface, display)
 
-        draw_triangular_corner_zones(self, display, surface)
+        draw_corner_zones(self, display, surface)

--- a/sr/robot/arenas/arena.py
+++ b/sr/robot/arenas/arena.py
@@ -13,9 +13,9 @@ import pypybox2d
 
 MARKERS_PER_WALL = 7
 
-ARENA_FLOOR_COLOR = (0x11, 0x18, 0x33)
+ARENA_FLOOR_COLOR = (0x12, 0x2B, 0x5E)
 ARENA_MARKINGS_COLOR = (0xD0, 0xD0, 0xD0)
-ARENA_MARKINGS_WIDTH = 2
+ARENA_MARKINGS_WIDTH = 3
 
 CORNER_COLOURS = (
     (0x00, 0xff, 0x00),
@@ -42,9 +42,9 @@ def fade_to_white(colour, opacity = 0.6):
 def lerp(delta, a, b):
     return delta*b + (1-delta)*a
 
-def draw_triangular_corner_zones(arena, display, surface):
+def draw_corner_zones(arena, display, surface, shape='Triangular'):
     """
-    Draw triangular corner zones for the given arena onto the given display.
+    Draw corner zones for the given arena onto the given display.
     """
 
     def get_coord(x, y):
@@ -65,18 +65,25 @@ def draw_triangular_corner_zones(arena, display, surface):
         line(a, c)
         line(b, c)
 
-    def scoring_zone(corner_pos, colour):
+    def scoring_zone(corner_pos, colour, shape):
         x, y = corner_pos
-        length = arena.scoring_zone_side
-        a = get_coord(towards_zero(x, length), y)
-        b = get_coord(x, towards_zero(y, length))
-        c = get_coord(x, y)
-
-        pygame.draw.polygon(surface, colour, (a, b, c), 0)
+        if shape is 'Triangular':
+            length = arena.scoring_zone_side
+            a = get_coord(towards_zero(x, length), y)
+            b = get_coord(x, towards_zero(y, length))
+            c = get_coord(x, y)
+            pygame.draw.polygon(surface, colour, (a, b, c), 0)
+        elif shape is 'Square':
+            length = arena.starting_zone_side
+            a = get_coord(towards_zero(x, length), y)
+            b = get_coord(x, y)
+            c = get_coord(x, towards_zero(y, length))
+            d = get_coord(towards_zero(x, length), towards_zero(y, length))
+            pygame.draw.polygon(surface, colour, (a, b, c, d), 0)
 
     for i, pos in enumerate(arena.corners):
         colour = fade_to_white(CORNER_COLOURS[i])
-        scoring_zone(pos, colour)
+        scoring_zone(pos, colour, shape=shape)
         starting_zone(pos)
 
 class Arena(object):
@@ -195,11 +202,15 @@ class Arena(object):
             if hasattr(obj, "tick"):
                 obj.tick(time_passed)
 
-    def draw_background(self, surface, display):
-        surface.fill(ARENA_FLOOR_COLOR)
-
+    def draw_motif(self, surface, display):
         # Motif
         motif = get_surface(self.motif_name)
         x, y = display.to_pixel_coord((0, 0), self)
         w, h = motif.get_size()
         surface.blit(motif, (x - w / 2, y - h / 2))
+
+    def draw_background(self, surface, display):
+        surface.fill(ARENA_FLOOR_COLOR)
+        self.draw_motif(surface, display)
+
+

--- a/sr/robot/arenas/caldera_arena.py
+++ b/sr/robot/arenas/caldera_arena.py
@@ -1,0 +1,125 @@
+from __future__ import division
+
+from math import ceil, cos, pi, sin
+
+import pygame
+
+from .arena import ARENA_FLOOR_COLOR, ARENA_MARKINGS_COLOR, ARENA_MARKINGS_WIDTH, Arena, draw_corner_zones
+from ..markers import Token
+
+
+# Perform a clockwise rotate around 0,0.
+def rotate(x, y, radians):
+    return (x * cos(radians) + y * -sin(radians)), (x * sin(radians) + y * cos(radians))
+
+
+PLATFORM_COLOUR = (0x68, 0x75, 0x91)
+
+class CalderaArena(Arena):
+    start_locations = [(-3.6, -3.6),
+                       (3.6, -3.6),
+                       (3.6, 3.6),
+                       (-3.6, 3.6)]
+
+    start_headings = [0.25 * pi,
+                      0.75 * pi,
+                      -0.75 * pi,
+                      -0.25 * pi]
+
+    def __init__(self, objects=None, wall_markers=True):
+        super(CalderaArena, self).__init__(objects, wall_markers)
+        self._init_tokens()
+
+    def _init_tokens(self):
+        token_ids = [28, 29, 30, 31]
+
+        token_locations_offsets_from_zone = [(0.5, 1.3),
+                                             (0.5, 1.5),
+                                             (0.5, 1.7),
+                                             (0.5, 1.9),
+                                             (0.5, 2.1),]
+
+        for zone in range(0, 4):
+            for i, location in enumerate(token_locations_offsets_from_zone):
+                rotated_location = rotate(location[0] - 4, location[1] - 4, (pi / 2) * zone)
+                token = Token(self, token_ids[zone], damping=0.5)
+                token.location = rotated_location
+                self.objects.append(token)
+
+    def draw_background(self, surface, display):
+        super(CalderaArena, self).draw_background(surface, display)
+
+        def line(start, end):
+            pygame.draw.line(surface, ARENA_MARKINGS_COLOR,
+                             display.to_pixel_coord(start), display.to_pixel_coord(end),
+                             ARENA_MARKINGS_WIDTH)
+
+        def line_symmetric(start, end):
+            """
+            Draw a line, double reflected on the X and Y axis
+            (creating 8 lines)
+            """
+            start_x, start_y = start
+            end_x, end_y = end
+            line((start_x, start_y), (end_x, end_y))
+            line((-start_x, start_y), (-end_x, end_y))
+            line((-start_x, -start_y), (-end_x, -end_y))
+            line((start_x, -start_y), (end_x, -end_y))
+            line((start_y, start_x), (end_y, end_x))
+            line((-start_y, start_x), (-end_y, end_x))
+            line((-start_y, -start_x), (-end_y, -end_x))
+            line((start_y, -start_x), (end_y, -end_x))
+
+        # Starting zones
+        self.starting_zone_side = 1
+        draw_corner_zones(self, display, surface, shape='Square')
+
+
+        # Grid
+        square_width = 1.200
+        start_pos = (-3, -3)
+        grid_dimensions = (5, 5)
+        quartered_grid_dims = (int(ceil(grid_dimensions[0]/2)), int(ceil(grid_dimensions[1]/2)))
+
+        def to_grid_pos(grid_x, grid_y):
+            return (start_pos[0] + grid_x * square_width,
+                    start_pos[1] + grid_y * square_width)
+
+        # Raised platform
+        # (These positions are in grid cell locations)
+        platform_outer_start = to_grid_pos(1, 1)
+        platform_outer_end = to_grid_pos(4, 4)
+        platform_inner_start = to_grid_pos(2, 2)
+        platform_inner_end = to_grid_pos(3, 3)
+
+        outer_platform = (
+            (platform_outer_start[0], platform_outer_start[1]),
+            (platform_outer_start[0], platform_outer_end[1]),
+            (platform_outer_end[0],   platform_outer_end[1]),
+            (platform_outer_end[0],   platform_outer_start[1]),
+        )
+
+        inner_platform = (
+            (platform_inner_start[0], platform_inner_start[1]),
+            (platform_inner_start[0], platform_inner_end[1]),
+            (platform_inner_end[0],   platform_inner_end[1]),
+            (platform_inner_end[0],   platform_inner_start[1]),
+        )
+
+        outer_platform = tuple([display.to_pixel_coord(p, self) for p in outer_platform])
+        pygame.draw.polygon(surface, PLATFORM_COLOUR, outer_platform, 0)
+
+        inner_platform = tuple([display.to_pixel_coord(p, self) for p in inner_platform])
+        pygame.draw.polygon(surface, ARENA_FLOOR_COLOR, inner_platform, 0)
+
+        # Redraw the motif on top
+        self.draw_motif(surface, display)
+
+        for x in range(quartered_grid_dims[0]):
+            for y in range(quartered_grid_dims[1]):
+                # Line to the right from the grid pos
+                pos_a = (start_pos[0]+(x*square_width), start_pos[1]+(y*square_width))
+                pos_b = (start_pos[0]+((x+1)*square_width), start_pos[1]+(y*square_width))
+                line_symmetric(pos_a, pos_b)
+
+

--- a/sr/robot/arenas/sunny_side_up_arena.py
+++ b/sr/robot/arenas/sunny_side_up_arena.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 from math import pi
 
-from .arena import Arena, draw_triangular_corner_zones
+from .arena import Arena, draw_corner_zones
 
 from ..markers import Token
 
@@ -37,4 +37,4 @@ class SunnySideUpArena(Arena):
     def draw_background(self, surface, display):
         super(SunnySideUpArena, self).draw_background(surface, display)
 
-        draw_triangular_corner_zones(self, display, surface)
+        draw_corner_zones(self, display, surface)

--- a/sr/robot/simulator.py
+++ b/sr/robot/simulator.py
@@ -3,12 +3,13 @@ from __future__ import division
 import threading
 import pygame
 
-from .arenas import PiratePlunderArena, CTFArena, SunnySideUpArena, ABCArena
+from .arenas import PiratePlunderArena, CTFArena, SunnySideUpArena, ABCArena, CalderaArena
 from .display import Display
 
-DEFAULT_GAME = 'pirate-plunder'
+DEFAULT_GAME = 'caldera'
 
-GAMES = {'pirate-plunder': PiratePlunderArena,
+GAMES = {'caldera': CalderaArena,
+         'pirate-plunder': PiratePlunderArena,
          'ctf': CTFArena,
          'sunny-side-up': SunnySideUpArena,
          'abc': ABCArena,


### PR DESCRIPTION
- Add the Caldera map design.
- Add Caldera to the list of maps.
- Change the default of run.py to be Caldera.
- Change the floor colour to better suit the new logo.
- Change `draw_triangle_corner_zones` to `draw_corner_zones`, and make
it take a `shape` param.

I couldn't simulate the raised platform because it's non-trivial on a 2D simulator, so I just painted it on.

Here's a screenshot of the new layout:
![Here's a screenshot of the arena](https://i.imgur.com/Y3QCN5O.png)